### PR TITLE
리사이즈 이벤트 발생 시 마지막 페이지 유지가 안되는 버그 수정

### DIFF
--- a/demo/src/components/footers/ViewerPageFooterToolbar.jsx
+++ b/demo/src/components/footers/ViewerPageFooterToolbar.jsx
@@ -65,7 +65,6 @@ ViewerPageFooterToolbar.propTypes = {
   pageViewPagination: PropTypes.shape({
     currentPage: PropTypes.number,
     totalPage: PropTypes.number,
-    readProcess: PropTypes.number,
   }).isRequired,
   isDisableComment: PropTypes.bool,
   movePageViewer: PropTypes.func.isRequired,

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -39,6 +39,8 @@ ViewerHelper.connect(store);
 PageCalculator.connect(store);
 ReadPositionHelper.connect(store);
 
+window.setDebugMode = ReadPositionHelper.setDebugMode.bind(ReadPositionHelper);
+
 class DemoViewer extends Component {
   componentWillMount() {
     const {

--- a/src/constants/ViewerScreenConstants.js
+++ b/src/constants/ViewerScreenConstants.js
@@ -3,6 +3,7 @@ import { updateObject } from '../util/Util';
 
 
 export const VIEWER_EMPTY_READ_POSITION = '-1#-1';
+export const INVALID_PAGE = -1;
 
 const _ViewerThemeType = {
   WHITE: 'white_theme',

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ export {
   selectContentType, // meta data 중 contentType 을 가져온다.
   selectViewerType, // meta data 중 viewerType 을 가져온다.
   selectBindingType, // meta data 중 bindingType 을 가져온다.
-  selectPageViewPagination, // page view 상태에서 pagination 데이터를 가져온다. (totalPage, currentPage, readProcess)
+  selectPageViewPagination, // page view 상태에서 pagination 데이터를 가져온다. (totalPage, currentPage)
   selectIsFullScreen, // header 와 footer 가 비활성화된 full screen 상태인지 여부를 가져온다.
   selectIsLoadingCompleted, // spine 의 로딩 완료 여부를 가져온다.
   selectViewerScreenSettings, // 뷰어 세팅값들을 가져온다.

--- a/src/redux/viewerScreen/ViewerScreen.path.js
+++ b/src/redux/viewerScreen/ViewerScreen.path.js
@@ -1,6 +1,11 @@
 import { AvailableViewerType, BindingType, ContentType } from '../../constants/ContentConstants';
-import { VIEWER_EMPTY_READ_POSITION, ViewerFontType, ViewerThemeType, ViewerType } from '../../constants/ViewerScreenConstants';
-
+import {
+  VIEWER_EMPTY_READ_POSITION,
+  INVALID_PAGE,
+  ViewerFontType,
+  ViewerThemeType,
+  ViewerType,
+} from '../../constants/ViewerScreenConstants';
 
 export const initialState = {
   spines: {},
@@ -13,8 +18,7 @@ export const initialState = {
   pageView: {
     calculatedPage: {
       currentPage: 1,
-      totalPage: 1,
-      readProcess: 0,
+      totalPage: INVALID_PAGE,
     },
   },
   viewerScreenSettings: {
@@ -41,7 +45,6 @@ export default {
   pageViewPagination: () => ['pageView', 'calculatedPage'],
   pageViewTotalPage: () => ['pageView', 'calculatedPage', 'totalPage'],
   pageViewCurrentPage: () => ['pageView', 'calculatedPage', 'currentPage'],
-  pageViewReadProcess: () => ['pageView', 'calculatedPage', 'readProcess'],
   viewerScreenSettings: () => ['viewerScreenSettings'],
   viewerScreenColorTheme: () => ['viewerScreenSettings', 'colorTheme'],
 };

--- a/src/util/Connector.js
+++ b/src/util/Connector.js
@@ -18,9 +18,9 @@ class Connector {
     return isExist(this.store);
   }
 
-  getDispatch() {
+  dispatch(action) {
     this.throwIfNotConnected();
-    return this.store.dispatch;
+    return this.store.dispatch(action);
   }
 
   getState() {

--- a/src/util/viewerScreen/ReadPositionHelper.js
+++ b/src/util/viewerScreen/ReadPositionHelper.js
@@ -16,8 +16,7 @@ class ReadPositionHelper extends Connector {
   }
 
   _getScrollMode() {
-    const state = this.store.getState();
-    const viewerScreenSettings = selectViewerScreenSettings(state);
+    const viewerScreenSettings = selectViewerScreenSettings(this.getState());
     return viewerScreenSettings.viewerType === ViewerType.SCROLL;
   }
 
@@ -66,26 +65,24 @@ class ReadPositionHelper extends Connector {
   }
 
   restorePosition() {
-    const { dispatch, getState } = this.store;
-    const readPosition = selectViewerReadPosition(getState());
+    const readPosition = selectViewerReadPosition(this.getState());
 
     const offset = this._getOffsetByNodeLocation(readPosition);
     if (isExist(offset)) {
       if (this._getScrollMode()) {
         setScrollTop(offset);
       } else {
-        dispatch(movePageViewer(offset + 1));
+        this.dispatch(movePageViewer(offset + 1));
       }
     }
   }
 
   updateChangedReadPosition() {
     const readPosition = this.getNodeLocation();
-    const { dispatch, getState } = this.store;
-    const originPosition = selectViewerReadPosition(getState());
+    const originPosition = selectViewerReadPosition(this.getState());
     //  readPosition reducer에 저장
     if (isExist(readPosition) && readPosition !== VIEWER_EMPTY_READ_POSITION && readPosition !== originPosition) {
-      dispatch(changedReadPosition(readPosition));
+      this.dispatch(changedReadPosition(readPosition));
     }
   }
 }

--- a/src/util/viewerScreen/ViewerHelper.js
+++ b/src/util/viewerScreen/ViewerHelper.js
@@ -70,8 +70,7 @@ class ViewerHelper extends Connector {
   }
 
   shouldSlideToPage(nextPage) {
-    const { getState } = this.store;
-    const pageView = selectPageViewPagination(getState());
+    const pageView = selectPageViewPagination(this.getState());
     const { totalPage } = pageView;
     return totalPage > nextPage && (nextPage - 1) * documentClientWidth() !== scrollLeft();
   }

--- a/src/views/viewerScreen/ScrollTouchable.jsx
+++ b/src/views/viewerScreen/ScrollTouchable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ViewerType } from '../../constants/ViewerScreenConstants';
 
 const ScrollTouchable = (props) => {
   const {
@@ -34,7 +35,7 @@ ScrollTouchable.propTypes = {
   children: PropTypes.node,
   onTouched: PropTypes.func,
   contentType: PropTypes.number,
-  viewerType: PropTypes.number,
+  viewerType: PropTypes.oneOf(ViewerType.toList()),
   footer: PropTypes.node,
   TouchableScreen: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   SizingWrapper: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,

--- a/src/views/viewerScreen/ViewerScreen.jsx
+++ b/src/views/viewerScreen/ViewerScreen.jsx
@@ -154,7 +154,7 @@ const createStyledViewerScreen = ({
     ignoreScroll: PropTypes.bool,
     isLoadingCompleted: PropTypes.bool,
     viewerScreenSettings: PropTypes.object,
-    viewerType: PropTypes.oneOf(ViewerType.toList()),
+    viewerType: PropTypes.oneOf(AvailableViewerType.toList()),
     contentType: PropTypes.oneOf(ContentType.toList()),
   };
 


### PR DESCRIPTION
페이지 보기일때 마지막 페이지에서 리사이즈 이벤트가 발생하면 페이지가 그대로 유지되기 때문에 컨텐츠 영역으로 넘어가 버리는 문제를 해결했습니다.

- 토탈 페이지 재계산시 현재 마지막 페이지에 있었다면, 계산된 토탈 페이지로 페이지 이동이 일어나도록 변경
- 스크롤 보기 방식에서 페이지 방식으로 변환할 때 이전 상태가 항상 마지막 페이지로 구분되는 문제가 있어, 스크롤 보기 방식일 때는 토탈 페이지를 초기화 값(-1)으로 세팅해 구분하도록 함
- 그 외 코드 정리
    - 사용하지 않는 `readProcess` 상태 정리
    - PropTypes에서 발생하는 warning 해결
    - `Connector`를 상속받은 클래스에서 `this.store`를 동일한 방식으로 접근하도록 함