### PR TITLE
(#41) Rename `ReducerBuilder` => `ImmutabilityHelper`

### DIFF
--- a/demo/src/redux/Viewer.reducer.js
+++ b/demo/src/redux/Viewer.reducer.js
@@ -1,28 +1,28 @@
 import { ViewerUiActions } from './Viewer.action';
 import { actions as ViewerScreenActions } from '../../../lib/index';
 import path, { initialState } from './Viewer.path';
-import ReducerBuilder from '../../../src/util/ReducerBuilder';
+import { ImmutableObjectBuilder } from '../../../src/util/ImmutabilityHelper';
 import { updateObject } from '../../../src/util/Util';
 import createReducer from '../../../src/util/Reducer';
 
 
-const onToggleViewerSetting = state => new ReducerBuilder(state)
+const onToggleViewerSetting = state => new ImmutableObjectBuilder(state)
   .set(path.isVisibleSettingPopup(), !state.ui.isVisibleSettingPopup)
   .build();
 
-const viewerSettingChanged = (state, action) => new ReducerBuilder(state)
+const viewerSettingChanged = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.viewerSettings(), updateObject(state.ui.viewerSettings, action.changeSetting))
   .build();
 
-const onScreenTouched = state => new ReducerBuilder(state)
+const onScreenTouched = state => new ImmutableObjectBuilder(state)
   .set(path.isVisibleSettingPopup(), false)
   .build();
 
-const onScreenScrolled = state => new ReducerBuilder(state)
+const onScreenScrolled = state => new ImmutableObjectBuilder(state)
   .set(path.isVisibleSettingPopup(), false)
   .build();
 
-const movePageViewer = state => new ReducerBuilder(state)
+const movePageViewer = state => new ImmutableObjectBuilder(state)
   .set(path.isVisibleSettingPopup(), false)
   .build();
 

--- a/src/redux/viewerScreen/ViewerScreen.reducer.js
+++ b/src/redux/viewerScreen/ViewerScreen.reducer.js
@@ -1,7 +1,7 @@
 import path, { initialState } from './ViewerScreen.path';
 import createReducer from '../../util/Reducer';
 import { actions } from './ViewerScreen.action';
-import ReducerBuilder from '../../util/ReducerBuilder';
+import { ImmutableObjectBuilder } from '../../util/ImmutabilityHelper';
 import { cloneObject, updateObject } from '../../util/Util';
 import { isScrolledToBottom, isScrolledToTop } from '../../util/CommonUi';
 import { ContentFormat } from '../../constants/ContentConstants';
@@ -11,52 +11,52 @@ const initializeViewerScreen = (state, action) => {
   return updateObject(cloneObject(initialState), { viewerScreenSettings });
 };
 
-const onScreenTouched = state => new ReducerBuilder(state)
+const onScreenTouched = state => new ImmutableObjectBuilder(state)
   .set(path.isFullScreen(), !state.isFullScreen)
   .build();
 
 const isEdgeOfScreen = () => (isScrolledToTop() || isScrolledToBottom());
 
-const onScreenScrolled = state => new ReducerBuilder(state)
+const onScreenScrolled = state => new ImmutableObjectBuilder(state)
   .set(path.isFullScreen(), !isEdgeOfScreen())
   .build();
 
-const calculatedPageViewer = (state, action) => new ReducerBuilder(state)
+const calculatedPageViewer = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.pageViewTotalPage(), action.page.totalPage)
   .build();
 
 const movePageViewer = (state, action) => {
   if (action.number > 0) {
-    return new ReducerBuilder(state)
+    return new ImmutableObjectBuilder(state)
       .set(path.pageViewCurrentPage(), action.number)
       .build();
   }
   return state;
 };
 
-const viewerScreenSettingChanged = (state, action) => new ReducerBuilder(state)
+const viewerScreenSettingChanged = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.viewerScreenSettings(), updateObject(state.viewerScreenSettings, action.changedSetting))
   .build();
 
-const updateMetaData = (state, action) => new ReducerBuilder(state)
+const updateMetaData = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.contentType(), action.contentType)
   .set(path.viewerType(), action.viewerType)
   .set(path.bindingType(), action.bindingType)
   .build();
 
-const renderSpine = (state, action) => new ReducerBuilder(state)
+const renderSpine = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.spine(action.index), action.spine)
   .set(path.contentFormat(), ContentFormat.EPUB)
   .set(path.isLoadingCompleted(), true)
   .build();
 
-const renderImages = (state, action) => new ReducerBuilder(state)
+const renderImages = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.images(), action.images)
   .set(path.contentFormat(), ContentFormat.IMAGE)
   .set(path.isLoadingCompleted(), true)
   .build();
 
-const changedReadPosition = (state, action) => new ReducerBuilder(state)
+const changedReadPosition = (state, action) => new ImmutableObjectBuilder(state)
   .set(path.readPosition(), action.position)
   .build();
 

--- a/src/util/ImmutabilityHelper.js
+++ b/src/util/ImmutabilityHelper.js
@@ -1,7 +1,7 @@
 import { cloneObject, nullSafeSet } from './Util';
 
 
-export default class ReducerBuilder {
+export class ImmutableObjectBuilder {
   constructor(state) {
     this._state = cloneObject(state);
   }
@@ -15,3 +15,5 @@ export default class ReducerBuilder {
     return this._state;
   }
 }
+
+export default { ImmutableObjectBuilder };


### PR DESCRIPTION
- Use more appropriate name
- Rename object builder class `ReducerBuilder` => `ImmutableObjectBuilder` also
#41 